### PR TITLE
2Remove leading/trailing whitespace from command arguments

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -59,7 +59,7 @@ func runBot(config botConfig, bot *tgbotapi.BotAPI) {
 
 func handleCommands(update tgbotapi.Update, bot *tgbotapi.BotAPI) error {
 	cmd := update.Message.Command()
-	args := update.Message.CommandArguments()
+	args := strings.Trim(update.Message.CommandArguments(), " ")
 
 	switch strings.ToLower(cmd) {
 	case "indent":


### PR DESCRIPTION
Not sure why this wasn't done by the library itself.